### PR TITLE
Update renameFiles.py

### DIFF
--- a/renameFiles.py
+++ b/renameFiles.py
@@ -108,6 +108,7 @@ if __name__=="__main__":
     fileRenameCounter = 0
     exceptedFiles = []
     renamedFiles = []
+    decoded_fileDirList = [x.decode('utf-8') for x in fileDirList]
     for file in fileDirList:
         oldPath, origFileName = os.path.split(file)
         fileCounter+= 1
@@ -137,6 +138,9 @@ if __name__=="__main__":
         if newFile != origFileName.decode('utf-8'):
             fileRenameCounter+=1
             print('Normalised "', origFileName.decode('utf-8'), '" to ', newFile)
+            if newFilePath in decoded_fileDirList:
+                print('The file could not be renamed, because a file with the same name already exists!')
+                exceptedFiles.append(file)
 
         # rename file if rename was set to true
         # collect files that cannot be renamed due to file name duplication
@@ -144,8 +148,7 @@ if __name__=="__main__":
             try:
                 os.rename(file, newFilePath)
             except FileExistsError:
-                print('The file could not be renamed, because a file with the same name already exists!')
-                exceptedFiles.append(file)
+                continue
 
     # rename directories, starting from within, i.e. reverse order of dirList
     dirCounter = 0

--- a/renameFiles.py
+++ b/renameFiles.py
@@ -141,14 +141,15 @@ if __name__=="__main__":
             if newFilePath in decoded_fileDirList:
                 print('The file could not be renamed, because a file with the same name already exists!')
                 exceptedFiles.append(file)
+            else:
 
         # rename file if rename was set to true
         # collect files that cannot be renamed due to file name duplication
-        if rename == 'true':
-            try:
-                os.rename(file, newFilePath)
-            except FileExistsError:
-                continue
+                if rename == 'true':
+                    try:
+                        os.rename(file, newFilePath)
+                    except FileExistsError:
+                        continue
 
     # rename directories, starting from within, i.e. reverse order of dirList
     dirCounter = 0


### PR DESCRIPTION
Function `os.rename` raised a `FileExistsError` only on Windows, while on Linux and Mac it directly overwrote the existing file. I tried to change the behavior of the script so that it doesn't use `os.rename` to check if the file already exists.